### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,5 +68,5 @@ If you use `mojo` itself it should be set (after you restarted your terminal).
 If not add it to your `.bashrc` or `.zshrc`:
 
 ```bash
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:~/.local/lib/mojo
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:~/.local/lib/arch-mojo
 ```


### PR DESCRIPTION
Updated README.md "missing libs" section to correctly inidcate `~/.local/lib/arch-mojo` needs to be added to `PATH` (was `~/.local/lib/mojo`)